### PR TITLE
`external-dns` support for public IP using DDNS

### DIFF
--- a/apps/plex/plex.yaml
+++ b/apps/plex/plex.yaml
@@ -47,6 +47,7 @@ spec:
           cert-manager.io/cluster-issuer: letsencrypt
           hajimari.io/enable: "true"
           hajimari.io/icon: plex
+          external-dns.alpha.kubernetes.io/target: "${DDNS}"
         ingressClassName: nginx
         hosts:
           - host: &plex-host plex.${PERSONAL_DOMAIN}

--- a/clusters/anton/flux-system/config-map.yaml
+++ b/clusters/anton/flux-system/config-map.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   SVC_PLEX_ADDR: 192.168.0.30
   PERSONAL_DOMAIN: lab.simo.sh
+  DDNS: mila.ddns.nbis.net

--- a/clusters/anton/flux-system/gotk-sync.yaml
+++ b/clusters/anton/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: external-dns-public-ip
   secretRef:
     name: flux-system
   url: ssh://git@github.com/fr3fou/home


### PR DESCRIPTION
This PR allows the creation of public DNS records using a simple annotation:
```yaml
  external-dns.alpha.kubernetes.io/target: "${DDNS}"
```